### PR TITLE
The little debugging is finished.

### DIFF
--- a/packages/device-comm/.env.example
+++ b/packages/device-comm/.env.example
@@ -1,0 +1,1 @@
+ONIONSAT_API_KEY=celeritas api key goes here

--- a/packages/device-comm/src/devices/device.ts
+++ b/packages/device-comm/src/devices/device.ts
@@ -1,29 +1,30 @@
 import WebsocketClient from "../ws_client.ts";
 
+export default abstract class DeviceBase {
+  protected abstract conn: WebsocketClient;
+  protected abstract readonly server_link: string;
+  protected abstract readonly exp_id: string;
+  protected abstract readonly device_name: string;
+  protected inited: boolean = false;
+  abstract sendCMD(cmd: string): Promise<boolean>;
+  abstract loadData(start: number | null, end: number | null): Promise<boolean>;
 
-export default abstract class DeviceBase{
-    protected abstract conn: WebsocketClient;
-    protected readonly abstract server_link: string;
-    protected readonly abstract exp_id: string;
-    protected inited: boolean = false;
-    abstract sendCMD(cmd: string): Promise<boolean>;
-    abstract loadData(start: number | null, end: number | null): Promise<boolean>;
-    async init(): Promise<boolean>{
-        const result: boolean = await this.conn.login(this.exp_id, Deno.env.get(this.exp_id)!);
-        console.log("login result: " + Deno.env.get(this.exp_id)!);
-        if(result){
-            this.inited = true;
-            return result
-        }
-        else{
-            this.inited = false;
-            return result;
-        }
-
+  async init(): Promise<boolean> {
+    const result: boolean = await this.conn.login(
+      this.exp_id,
+      Deno.env.get(`${this.device_name.toUpperCase()}_API_KEY`)!,
+    );
+    if (result) {
+      this.inited = true;
+      return result;
+    } else {
+      this.inited = false;
+      throw new Error("Failed to log in!");
     }
-    close(){
-        this.conn.close();
-        this.inited = false;
-    }
+  }
 
+  async close() {
+    await this.conn.close();
+    this.inited = false;
+  }
 }

--- a/packages/device-comm/src/devices/onionsat.ts
+++ b/packages/device-comm/src/devices/onionsat.ts
@@ -1,40 +1,46 @@
 import DeviceBase from "./device.ts";
 import WebsocketClient from "../ws_client.ts";
 
-export default class OnionSatDevice extends DeviceBase{
-    server_link: string;
-    exp_id: string;
-    conn: WebsocketClient;
+export default class OnionSatDevice extends DeviceBase {
+  protected server_link: string;
+  protected exp_id: string;
+  protected device_name: string;
+  protected conn: WebsocketClient;
 
+  constructor() {
+    super();
+    this.server_link = "ws://gru.onionsat.com:8080/";
+    this.exp_id = "celeritas";
+    this.device_name = "ONIONSAT";
+    this.conn = new WebsocketClient(this.server_link);
+  }
 
-    constructor(){
-        super();
-        this.server_link = "ws://gru.onionsat.com:8080/";
-        this.exp_id = "celeritas";
-        this.conn = new WebsocketClient(this.server_link);
+  override async init(): Promise<boolean> {
+    await this.conn.read();
+    return await super.init();
+  }
 
+  async loadData(start: number | null, end: number | null): Promise<boolean> {
+    let result: boolean = false;
+    if (this.inited) {
+      if (start == null) {
+        start = 1;
+      }
+      if (end == null) {
+        end = Math.floor(Date.now() / 1000);
+      }
+      const message: string = await this.conn.execCmd("getEXPData", [
+        this.exp_id,
+        start.toString(),
+        end.toString(),
+      ]);
+      console.log("sending data. Message: " + message);
+      result = true;
     }
+    return result;
+  }
 
-    async loadData(start: number | null, end: number | null): Promise<boolean>{
-        let result: boolean = false;
-        console.log("loading data", this.inited);
-        if(this.inited){
-            if(start == null){
-                start = 1;
-            }
-            if(end == null){
-                end = Math.floor(Date.now() / 1000);
-            }
-            const message: string = await this.conn.execCmd("getEXPData", [start.toString(), end.toString()]);
-            console.log("sending data. Message: " + message);
-            result = true;
-        }
-        return result;
-
-    }
-
-    async sendCMD(cmd: string):Promise<boolean>{
-        return false;
-    }
-
+  async sendCMD(cmd: string): Promise<boolean> {
+    return false;
+  }
 }

--- a/packages/device-comm/src/ws_client.ts
+++ b/packages/device-comm/src/ws_client.ts
@@ -33,7 +33,7 @@ export default class WebsocketClient {
         }
       }
       dataToSend += ")";
-      console.log("sending data: " + dataToSend);
+      await this.conn.wait_for("open");
       this.conn.send(dataToSend);
       return await this.read();
     }
@@ -41,10 +41,9 @@ export default class WebsocketClient {
   async login(exp_id: string, api_key: string): Promise<boolean> {
     try {
       const responseText = await this.execCmd("login", [exp_id, api_key]);
-      console.log("login response: " + responseText);
-      return responseText === "true";
+      return responseText.toLowerCase() === `${exp_id.toLowerCase()} logged in`;
     } catch (err) {
-      return false;
+      throw err;
     }
   }
 

--- a/packages/device-comm/test/devices_test.ts
+++ b/packages/device-comm/test/devices_test.ts
@@ -1,8 +1,9 @@
 import { assertEquals } from "@std/assert";
 import OnionsatDevice from "../src/devices/onionsat.ts";
 
-Deno.test("Onionsat Packet Download", async function onionsat_test()  {
-    let os = new OnionsatDevice();
-    await os.init();
-    assertEquals((await os.loadData(4, 12)), true);
+Deno.test("Onionsat Packet Download", async function onionsat_test() {
+  let os = new OnionsatDevice();
+  await os.init();
+  assertEquals(await os.loadData(4, 12), true);
+  await os.close();
 });


### PR DESCRIPTION
Changes:
 - `device.ts`: introduced a new pror called `device_name: string` which is a string identifier for each device subclass. Used for the API key getting.
 - `.env.example`: an example setup of what your .env.local file should look like. Do not put any credenetials here.
 - ˙onionsat.ts`: adjustments for `device.ts` (see above) and added an extra websocket read before the common init routine in order to handle the ONIONSAT welcome message
 - `ws_client.ts`: adjusted the login response validation to the real case and if something goes wrong throw the error instead of just returning false.
 - `devices_test.ts`: closed the connection at the end of the test